### PR TITLE
build: use whiskers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers xed.tera

--- a/src/frappe.xml
+++ b/src/frappe.xml
@@ -24,37 +24,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 -->
-<style-scheme id="catppuccin-frappe" _name="Catppuccin Frappe" version="1.0">
+<style-scheme id="catppuccin-frappe" _name="Catppuccin Frappé" version="1.0">
   <author>Catppuccin</author>
-  <_description>Soothing pastel theme for xed</_description>
+  <_description>Soothing pastel theme for Xed</_description>
 
-  <!-- Catppuccin Frappe Palette -->
-  <color name="crust"  value="#232634"/>
-  <color name="mantle"  value="#292c3c"/>
-  <color name="base"  value="#303446"/>
-  <color name="surface0"  value="#414559"/>
-  <color name="surface1"  value="#51576d"/>
-  <color name="surface2"  value="#626880"/>
-  <color name="overlay0"  value="#737994"/>
-  <color name="overlay1"  value="#838ba7"/>
-  <color name="overlay2"  value="#949cbb"/>
-  <color name="subtext0"  value="#a5adce"/>
-  <color name="subtext1"  value="#b5bfe2"/>
-  <color name="text"  value="#c6d0f5"/>
-  <color name="lavender"  value="#babbf1"/>
-  <color name="blue"  value="#8caaee"/>
-  <color name="sapphire"  value="#85c1dc"/>
-  <color name="sky"  value="#99d1db"/>
-  <color name="teal"  value="#81c8be"/>
-  <color name="green"  value="#a6d189"/>
-  <color name="yellow"  value="#e5c890"/>
-  <color name="peach"  value="#ef9f76"/>
-  <color name="maroon"  value="#ea999c"/>
-  <color name="red"  value="#e78284"/>
-  <color name="mauve"  value="#ca9ee6"/>
-  <color name="pink"  value="#f4b8e4"/>
-  <color name="flamingo"  value="#eebebe"/>
+  <!-- Catppuccin Frappé -->
   <color name="rosewater"  value="#f2d5cf"/>
+  <color name="flamingo"  value="#eebebe"/>
+  <color name="pink"  value="#f4b8e4"/>
+  <color name="mauve"  value="#ca9ee6"/>
+  <color name="red"  value="#e78284"/>
+  <color name="maroon"  value="#ea999c"/>
+  <color name="peach"  value="#ef9f76"/>
+  <color name="yellow"  value="#e5c890"/>
+  <color name="green"  value="#a6d189"/>
+  <color name="teal"  value="#81c8be"/>
+  <color name="sky"  value="#99d1db"/>
+  <color name="sapphire"  value="#85c1dc"/>
+  <color name="blue"  value="#8caaee"/>
+  <color name="lavender"  value="#babbf1"/>
+  <color name="text"  value="#c6d0f5"/>
+  <color name="subtext1"  value="#b5bfe2"/>
+  <color name="subtext0"  value="#a5adce"/>
+  <color name="overlay2"  value="#949cbb"/>
+  <color name="overlay1"  value="#838ba7"/>
+  <color name="overlay0"  value="#737994"/>
+  <color name="surface2"  value="#626880"/>
+  <color name="surface1"  value="#51576d"/>
+  <color name="surface0"  value="#414559"/>
+  <color name="base"  value="#303446"/>
+  <color name="mantle"  value="#292c3c"/>
+  <color name="crust"  value="#232634"/>
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>

--- a/src/frappe.xml
+++ b/src/frappe.xml
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 -->
-<style-scheme id="catppuccin-frappe" _name="Catppuccin Frappé" version="1.0">
+<style-scheme id="catppuccin-frappe" _name="Catppuccin Frappe" version="1.0">
   <author>Catppuccin</author>
   <_description>Soothing pastel theme for Xed</_description>
 

--- a/src/latte.xml
+++ b/src/latte.xml
@@ -26,35 +26,35 @@ SOFTWARE.
 -->
 <style-scheme id="catppuccin-latte" _name="Catppuccin Latte" version="1.0">
   <author>Catppuccin</author>
-  <_description>Soothing pastel theme for xed</_description>
+  <_description>Soothing pastel theme for Xed</_description>
 
-  <!-- Catppuccin Latte Palette -->
-  <color name="crust"  value="#dce0e8"/>
-  <color name="mantle"  value="#e6e9ef"/>
-  <color name="base"  value="#eff1f5"/>
-  <color name="surface0"  value="#ccd0da"/>
-  <color name="surface1"  value="#bcc0cc"/>
-  <color name="surface2"  value="#acb0be"/>
-  <color name="overlay0"  value="#9ca0b0"/>
-  <color name="overlay1"  value="#8c8fa1"/>
-  <color name="overlay2"  value="#7c7f93"/>
-  <color name="subtext0"  value="#6c6f85"/>
-  <color name="subtext1"  value="#5c5f77"/>
-  <color name="text"  value="#4c4f69"/>
-  <color name="lavender"  value="#7287fd"/>
-  <color name="blue"  value="#1e66f5"/>
-  <color name="sapphire"  value="#209fb5"/>
-  <color name="sky"  value="#04a5e5"/>
-  <color name="teal"  value="#179299"/>
-  <color name="green"  value="#40a02b"/>
-  <color name="yellow"  value="#df8e1d"/>
-  <color name="peach"  value="#fe640b"/>
-  <color name="maroon"  value="#e64553"/>
-  <color name="red"  value="#d20f39"/>
-  <color name="mauve"  value="#8839ef"/>
-  <color name="pink"  value="#ea76cb"/>
-  <color name="flamingo"  value="#dd7878"/>
+  <!-- Catppuccin Latte -->
   <color name="rosewater"  value="#dc8a78"/>
+  <color name="flamingo"  value="#dd7878"/>
+  <color name="pink"  value="#ea76cb"/>
+  <color name="mauve"  value="#8839ef"/>
+  <color name="red"  value="#d20f39"/>
+  <color name="maroon"  value="#e64553"/>
+  <color name="peach"  value="#fe640b"/>
+  <color name="yellow"  value="#df8e1d"/>
+  <color name="green"  value="#40a02b"/>
+  <color name="teal"  value="#179299"/>
+  <color name="sky"  value="#04a5e5"/>
+  <color name="sapphire"  value="#209fb5"/>
+  <color name="blue"  value="#1e66f5"/>
+  <color name="lavender"  value="#7287fd"/>
+  <color name="text"  value="#4c4f69"/>
+  <color name="subtext1"  value="#5c5f77"/>
+  <color name="subtext0"  value="#6c6f85"/>
+  <color name="overlay2"  value="#7c7f93"/>
+  <color name="overlay1"  value="#8c8fa1"/>
+  <color name="overlay0"  value="#9ca0b0"/>
+  <color name="surface2"  value="#acb0be"/>
+  <color name="surface1"  value="#bcc0cc"/>
+  <color name="surface0"  value="#ccd0da"/>
+  <color name="base"  value="#eff1f5"/>
+  <color name="mantle"  value="#e6e9ef"/>
+  <color name="crust"  value="#dce0e8"/>
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>

--- a/src/macchiato.xml
+++ b/src/macchiato.xml
@@ -26,37 +26,37 @@ SOFTWARE.
 -->
 <style-scheme id="catppuccin-macchiato" _name="Catppuccin Macchiato" version="1.0">
   <author>Catppuccin</author>
-  <_description>Soothing pastel theme for xed</_description>
+  <_description>Soothing pastel theme for Xed</_description>
 
-  <!-- Catppuccin Macchiato Palette -->
-  <color name="crust"  value="#181926"/>
-  <color name="mantle"  value="#1e2030"/>
-  <color name="base"  value="#24273a"/>
-  <color name="surface0"  value="#363a4f"/>
-  <color name="surface1"  value="#494d64"/>
-  <color name="surface2"  value="#5b6078"/>
-  <color name="overlay0"  value="#6e738d"/>
-  <color name="overlay1"  value="#8087a2"/>
-  <color name="overlay2"  value="#939ab7"/>
-  <color name="subtext0"  value="#a5adcb"/>
-  <color name="subtext1"  value="#b8c0e0"/>
-  <color name="text"  value="#cad3f5"/>
-  <color name="lavender"  value="#b7bdf8"/>
-  <color name="blue"  value="#8aadf4"/>
-  <color name="sapphire"  value="#7dc4e4"/>
-  <color name="sky"  value="#91d7e3"/>
-  <color name="teal"  value="#8bd5ca"/>
-  <color name="green"  value="#a6da95"/>
-  <color name="yellow"  value="#eed49f"/>
-  <color name="peach"  value="#f5a97f"/>
-  <color name="maroon"  value="#ee99a0"/>
-  <color name="red"  value="#ed8796"/>
-  <color name="mauve"  value="#c6a0f6"/>
-  <color name="pink"  value="#f5bde6"/>
-  <color name="flamingo"  value="#f0c6c6"/>
+  <!-- Catppuccin Macchiato -->
   <color name="rosewater"  value="#f4dbd6"/>
+  <color name="flamingo"  value="#f0c6c6"/>
+  <color name="pink"  value="#f5bde6"/>
+  <color name="mauve"  value="#c6a0f6"/>
+  <color name="red"  value="#ed8796"/>
+  <color name="maroon"  value="#ee99a0"/>
+  <color name="peach"  value="#f5a97f"/>
+  <color name="yellow"  value="#eed49f"/>
+  <color name="green"  value="#a6da95"/>
+  <color name="teal"  value="#8bd5ca"/>
+  <color name="sky"  value="#91d7e3"/>
+  <color name="sapphire"  value="#7dc4e4"/>
+  <color name="blue"  value="#8aadf4"/>
+  <color name="lavender"  value="#b7bdf8"/>
+  <color name="text"  value="#cad3f5"/>
+  <color name="subtext1"  value="#b8c0e0"/>
+  <color name="subtext0"  value="#a5adcb"/>
+  <color name="overlay2"  value="#939ab7"/>
+  <color name="overlay1"  value="#8087a2"/>
+  <color name="overlay0"  value="#6e738d"/>
+  <color name="surface2"  value="#5b6078"/>
+  <color name="surface1"  value="#494d64"/>
+  <color name="surface0"  value="#363a4f"/>
+  <color name="base"  value="#24273a"/>
+  <color name="mantle"  value="#1e2030"/>
+  <color name="crust"  value="#181926"/>
 
-   <!-- Global Settings -->
+  <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>
   <style name="selection"                   foreground="crust" background="text"/>
   <style name="cursor"                      foreground="subtext0"/>

--- a/xed.tera
+++ b/xed.tera
@@ -11,28 +11,7 @@ whiskers:
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-MIT License
-
-Copyright (c) 2021 Catppuccin
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+{{ read_file(path="LICENSE") }}
 -->
 <style-scheme id="catppuccin-{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" version="1.0">
   <author>Catppuccin</author>

--- a/xed.tera
+++ b/xed.tera
@@ -1,3 +1,13 @@
+---
+whiskers:
+  version: "2.2.0"
+  matrix:
+    - flavor
+  filename: "src/{{ flavor.identifier }}.xml"
+---
+
+{%- set palette = flavor.colors -%}
+
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
@@ -24,37 +34,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 -->
-<style-scheme id="catppuccin-mocha" _name="Catppuccin Mocha" version="1.0">
+<style-scheme id="catppuccin-{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" version="1.0">
   <author>Catppuccin</author>
   <_description>Soothing pastel theme for Xed</_description>
 
-  <!-- Catppuccin Mocha -->
-  <color name="rosewater"  value="#f5e0dc"/>
-  <color name="flamingo"  value="#f2cdcd"/>
-  <color name="pink"  value="#f5c2e7"/>
-  <color name="mauve"  value="#cba6f7"/>
-  <color name="red"  value="#f38ba8"/>
-  <color name="maroon"  value="#eba0ac"/>
-  <color name="peach"  value="#fab387"/>
-  <color name="yellow"  value="#f9e2af"/>
-  <color name="green"  value="#a6e3a1"/>
-  <color name="teal"  value="#94e2d5"/>
-  <color name="sky"  value="#89dceb"/>
-  <color name="sapphire"  value="#74c7ec"/>
-  <color name="blue"  value="#89b4fa"/>
-  <color name="lavender"  value="#b4befe"/>
-  <color name="text"  value="#cdd6f4"/>
-  <color name="subtext1"  value="#bac2de"/>
-  <color name="subtext0"  value="#a6adc8"/>
-  <color name="overlay2"  value="#9399b2"/>
-  <color name="overlay1"  value="#7f849c"/>
-  <color name="overlay0"  value="#6c7086"/>
-  <color name="surface2"  value="#585b70"/>
-  <color name="surface1"  value="#45475a"/>
-  <color name="surface0"  value="#313244"/>
-  <color name="base"  value="#1e1e2e"/>
-  <color name="mantle"  value="#181825"/>
-  <color name="crust"  value="#11111b"/>
+  <!-- Catppuccin {{ flavor.name }} -->
+  {%- for _, color in palette %}
+  <color name="{{ color.identifier }}"  value="#{{ color.hex }}"/>
+  {%- endfor %}
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>

--- a/xed.tera
+++ b/xed.tera
@@ -13,7 +13,7 @@ whiskers:
 
 {{ read_file(path="LICENSE") }}
 -->
-<style-scheme id="catppuccin-{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" version="1.0">
+<style-scheme id="catppuccin-{{ flavor.identifier }}" _name="Catppuccin {{ flavor.identifier | capitalize }}" version="1.0">
   <author>Catppuccin</author>
   <_description>Soothing pastel theme for Xed</_description>
 


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.xml` files directly, edit the `xed.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.

~~Draft until https://github.com/catppuccin/toolbox/pull/217 so we can pull in the LICENSE file lol.~~