### PR TITLE
feat: support more langs / align better with style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 ## 💝 Thanks to
 
 - [justTOBBI](https://github.com/justTOBBI)
+- [Saevyn](https://github.com/Saevyn)
 
 &nbsp;
 

--- a/src/frappe.xml
+++ b/src/frappe.xml
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 -->
-<style-scheme id="catppuccin-frappe" _name="Catppuccin Frappe" version="1.0">
+<style-scheme id="catppuccin-frappe" _name="Catppuccin Frappé" version="1.0">
   <author>Catppuccin</author>
   <_description>Soothing pastel theme for Xed</_description>
 
@@ -58,31 +58,41 @@ SOFTWARE.
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>
-  <style name="selection"                   foreground="crust" background="text"/>
-  <style name="cursor"                      foreground="subtext0"/>
-  <style name="secondary-cursor"            foreground="subtext1"/>
-  <style name="current-line"                background="text"/>
-  <style name="line-numbers"                foreground="text" background="base"/>
+  <style name="selection"                   foreground="text" background="surface2"/>
+  <style name="selection-unfocused"         foreground="text" background="overlay2"/>
+  <style name="cursor"                      foreground="rosewater"/>
+  <style name="secondary-cursor"            foreground="rosewater"/>
+  <style name="current-line"                background="surface0"/>
+  <style name="line-numbers"                foreground="overlay1" background="base"/>
   <style name="background-pattern"          background="rosewater"/>
 
   <!-- Bracket Matching -->
-  <style name="bracket-match"               foreground="crust" background="base"/>
+  <style name="bracket-match"               foreground="mauve"/>
   <style name="bracket-mismatch"            foreground="red" background="base"/>
 
   <!-- Right Margin -->
-  <style name="right-margin"                foreground="crust" background="base"/>
+  <style name="right-margin"                foreground="text" background="crust"/>
 
   <!-- Search Matching -->
-  <style name="search-match"                foreground="crust" background="yellow"/>
+  <style name="search-match"                foreground="text" background="teal"/>
 
   <!-- Comments -->
-  <style name="def:comment"                 foreground="subtext0"/>
-  <style name="def:shebang"                 foreground="subtext0" bold="true"/>
+  <style name="def:comment"                 foreground="overlay2"/>
+  <style name="def:shebang"                 foreground="overlay0" bold="true"/>
   <style name="def:doc-comment-element"     italic="true"/>
 
-  <!-- Constants -->
-  <style name="def:constant"                foreground="green"/>
-  <style name="def:special-char"            foreground="green"/>
+  <!-- Constants and variables -->
+  <style name="def:constant"                foreground="peach"/>
+  <style name="def:string"                  foreground="green"/>
+  <style name="def:special-char"            foreground="pink"/>
+  <style name="def:special-constant"        foreground="peach" bold="true"/>
+  <style name="def:number"                  foreground="peach"/>
+  <style name="def:floating-point"          foreground="peach"/>
+  <style name="def:boolean"                 foreground="peach"/>
+  <style name="def:keyword"                 foreground="mauve" bold="true"/>
+  <style name="def:builtin"                 foreground="red" bold="true"/>
+  <style name="def:variable"                foreground="maroon"/>
+
 
   <!-- Identifiers -->
   <style name="def:identifier"              foreground="blue"/>
@@ -94,22 +104,35 @@ SOFTWARE.
   <style name="def:type"                    foreground="yellow"/>
 
   <!-- Operators -->
-  <style name="def:operator"                foreground="teal"/>
+  <style name="def:operator"                foreground="sky"/>
+
+  <!-- Markup -->
+  <style name="def:emphasis"                italic="true"/>
+  <style name="def:strong-emphasis"         foreground="yellow" bold="true"/>
+  <style name="def:inline-code"             foreground="green"/>
+  <style name="def:insertion"               underline="single"/>
+  <style name="def:deletion"                strikethrough="true"/>
+  <style name="def:link-text"               foreground="lavender"/>
+  <style name="def:link-symbol"             foreground="blue" bold="true"/>
+  <style name="def:link-destination"        foreground="blue" italic="true" underline="single"/>
+  <style name="def:heading"                 foreground="red" bold="true"/>
+  <style name="def:thematic-break"          foreground="green" bold="true"/>
+  <style name="def:preformatted-section"    foreground="green"/>
+  <style name="def:list-marker"             foreground="teal" bold="true"/>
 
   <!-- Others -->
   <style name="def:preprocessor"            foreground="sky"/>
   <style name="def:error"                   foreground="red" bold="true"/>
+  <style name="def:warning"                 background="yellow"/>
   <style name="def:note"                    foreground="lavender" bold="true"/>
+  <style name="def:net-address"             foreground="blue" italic="true" underline="single"/>
   <style name="def:underlined"              italic="true" underline="single"/>
+  <style name="def:function"                foreground="blue"/>
 
-  <!-- Heading styles, uncomment to enable -->
-  <!--
-  <style name="def:heading0"                scale="5.0"/>
-  <style name="def:heading1"                scale="2.5"/>
-  <style name="def:heading2"                scale="2.0"/>
-  <style name="def:heading3"                scale="1.7"/>
-  <style name="def:heading4"                scale="1.5"/>
-  <style name="def:heading5"                scale="1.3"/>
-  <style name="def:heading6"                scale="1.2"/>
-  -->
+  <!-- Diff -->
+  <style name="diff:location"               foreground="peach"/>
+  <style name="diff:changed-line"           foreground="blue"/>
+  <style name="diff:added-line"             foreground="green"/>
+  <style name="diff:removed-line"           foreground="red"/>
+  <style name="diff:special-case"           foreground="peach"/>
 </style-scheme>

--- a/src/latte.xml
+++ b/src/latte.xml
@@ -58,31 +58,41 @@ SOFTWARE.
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>
-  <style name="selection"                   foreground="crust" background="text"/>
-  <style name="cursor"                      foreground="subtext0"/>
-  <style name="secondary-cursor"            foreground="subtext1"/>
-  <style name="current-line"                background="text"/>
-  <style name="line-numbers"                foreground="text" background="base"/>
+  <style name="selection"                   foreground="text" background="surface2"/>
+  <style name="selection-unfocused"         foreground="text" background="overlay2"/>
+  <style name="cursor"                      foreground="rosewater"/>
+  <style name="secondary-cursor"            foreground="rosewater"/>
+  <style name="current-line"                background="surface0"/>
+  <style name="line-numbers"                foreground="overlay1" background="base"/>
   <style name="background-pattern"          background="rosewater"/>
 
   <!-- Bracket Matching -->
-  <style name="bracket-match"               foreground="crust" background="base"/>
+  <style name="bracket-match"               foreground="mauve"/>
   <style name="bracket-mismatch"            foreground="red" background="base"/>
 
   <!-- Right Margin -->
-  <style name="right-margin"                foreground="crust" background="base"/>
+  <style name="right-margin"                foreground="text" background="crust"/>
 
   <!-- Search Matching -->
-  <style name="search-match"                foreground="crust" background="yellow"/>
+  <style name="search-match"                foreground="text" background="teal"/>
 
   <!-- Comments -->
-  <style name="def:comment"                 foreground="subtext0"/>
-  <style name="def:shebang"                 foreground="subtext0" bold="true"/>
+  <style name="def:comment"                 foreground="overlay2"/>
+  <style name="def:shebang"                 foreground="overlay0" bold="true"/>
   <style name="def:doc-comment-element"     italic="true"/>
 
-  <!-- Constants -->
-  <style name="def:constant"                foreground="green"/>
-  <style name="def:special-char"            foreground="green"/>
+  <!-- Constants and variables -->
+  <style name="def:constant"                foreground="peach"/>
+  <style name="def:string"                  foreground="green"/>
+  <style name="def:special-char"            foreground="pink"/>
+  <style name="def:special-constant"        foreground="peach" bold="true"/>
+  <style name="def:number"                  foreground="peach"/>
+  <style name="def:floating-point"          foreground="peach"/>
+  <style name="def:boolean"                 foreground="peach"/>
+  <style name="def:keyword"                 foreground="mauve" bold="true"/>
+  <style name="def:builtin"                 foreground="red" bold="true"/>
+  <style name="def:variable"                foreground="maroon"/>
+
 
   <!-- Identifiers -->
   <style name="def:identifier"              foreground="blue"/>
@@ -94,22 +104,35 @@ SOFTWARE.
   <style name="def:type"                    foreground="yellow"/>
 
   <!-- Operators -->
-  <style name="def:operator"                foreground="teal"/>
+  <style name="def:operator"                foreground="sky"/>
+
+  <!-- Markup -->
+  <style name="def:emphasis"                italic="true"/>
+  <style name="def:strong-emphasis"         foreground="yellow" bold="true"/>
+  <style name="def:inline-code"             foreground="green"/>
+  <style name="def:insertion"               underline="single"/>
+  <style name="def:deletion"                strikethrough="true"/>
+  <style name="def:link-text"               foreground="lavender"/>
+  <style name="def:link-symbol"             foreground="blue" bold="true"/>
+  <style name="def:link-destination"        foreground="blue" italic="true" underline="single"/>
+  <style name="def:heading"                 foreground="red" bold="true"/>
+  <style name="def:thematic-break"          foreground="green" bold="true"/>
+  <style name="def:preformatted-section"    foreground="green"/>
+  <style name="def:list-marker"             foreground="teal" bold="true"/>
 
   <!-- Others -->
   <style name="def:preprocessor"            foreground="sky"/>
   <style name="def:error"                   foreground="red" bold="true"/>
+  <style name="def:warning"                 background="yellow"/>
   <style name="def:note"                    foreground="lavender" bold="true"/>
+  <style name="def:net-address"             foreground="blue" italic="true" underline="single"/>
   <style name="def:underlined"              italic="true" underline="single"/>
+  <style name="def:function"                foreground="blue"/>
 
-  <!-- Heading styles, uncomment to enable -->
-  <!--
-  <style name="def:heading0"                scale="5.0"/>
-  <style name="def:heading1"                scale="2.5"/>
-  <style name="def:heading2"                scale="2.0"/>
-  <style name="def:heading3"                scale="1.7"/>
-  <style name="def:heading4"                scale="1.5"/>
-  <style name="def:heading5"                scale="1.3"/>
-  <style name="def:heading6"                scale="1.2"/>
-  -->
+  <!-- Diff -->
+  <style name="diff:location"               foreground="peach"/>
+  <style name="diff:changed-line"           foreground="blue"/>
+  <style name="diff:added-line"             foreground="green"/>
+  <style name="diff:removed-line"           foreground="red"/>
+  <style name="diff:special-case"           foreground="peach"/>
 </style-scheme>

--- a/src/macchiato.xml
+++ b/src/macchiato.xml
@@ -58,31 +58,41 @@ SOFTWARE.
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>
-  <style name="selection"                   foreground="crust" background="text"/>
-  <style name="cursor"                      foreground="subtext0"/>
-  <style name="secondary-cursor"            foreground="subtext1"/>
-  <style name="current-line"                background="text"/>
-  <style name="line-numbers"                foreground="text" background="base"/>
+  <style name="selection"                   foreground="text" background="surface2"/>
+  <style name="selection-unfocused"         foreground="text" background="overlay2"/>
+  <style name="cursor"                      foreground="rosewater"/>
+  <style name="secondary-cursor"            foreground="rosewater"/>
+  <style name="current-line"                background="surface0"/>
+  <style name="line-numbers"                foreground="overlay1" background="base"/>
   <style name="background-pattern"          background="rosewater"/>
 
   <!-- Bracket Matching -->
-  <style name="bracket-match"               foreground="crust" background="base"/>
+  <style name="bracket-match"               foreground="mauve"/>
   <style name="bracket-mismatch"            foreground="red" background="base"/>
 
   <!-- Right Margin -->
-  <style name="right-margin"                foreground="crust" background="base"/>
+  <style name="right-margin"                foreground="text" background="crust"/>
 
   <!-- Search Matching -->
-  <style name="search-match"                foreground="crust" background="yellow"/>
+  <style name="search-match"                foreground="text" background="teal"/>
 
   <!-- Comments -->
-  <style name="def:comment"                 foreground="subtext0"/>
-  <style name="def:shebang"                 foreground="subtext0" bold="true"/>
+  <style name="def:comment"                 foreground="overlay2"/>
+  <style name="def:shebang"                 foreground="overlay0" bold="true"/>
   <style name="def:doc-comment-element"     italic="true"/>
 
-  <!-- Constants -->
-  <style name="def:constant"                foreground="green"/>
-  <style name="def:special-char"            foreground="green"/>
+  <!-- Constants and variables -->
+  <style name="def:constant"                foreground="peach"/>
+  <style name="def:string"                  foreground="green"/>
+  <style name="def:special-char"            foreground="pink"/>
+  <style name="def:special-constant"        foreground="peach" bold="true"/>
+  <style name="def:number"                  foreground="peach"/>
+  <style name="def:floating-point"          foreground="peach"/>
+  <style name="def:boolean"                 foreground="peach"/>
+  <style name="def:keyword"                 foreground="mauve" bold="true"/>
+  <style name="def:builtin"                 foreground="red" bold="true"/>
+  <style name="def:variable"                foreground="maroon"/>
+
 
   <!-- Identifiers -->
   <style name="def:identifier"              foreground="blue"/>
@@ -94,22 +104,35 @@ SOFTWARE.
   <style name="def:type"                    foreground="yellow"/>
 
   <!-- Operators -->
-  <style name="def:operator"                foreground="teal"/>
+  <style name="def:operator"                foreground="sky"/>
+
+  <!-- Markup -->
+  <style name="def:emphasis"                italic="true"/>
+  <style name="def:strong-emphasis"         foreground="yellow" bold="true"/>
+  <style name="def:inline-code"             foreground="green"/>
+  <style name="def:insertion"               underline="single"/>
+  <style name="def:deletion"                strikethrough="true"/>
+  <style name="def:link-text"               foreground="lavender"/>
+  <style name="def:link-symbol"             foreground="blue" bold="true"/>
+  <style name="def:link-destination"        foreground="blue" italic="true" underline="single"/>
+  <style name="def:heading"                 foreground="red" bold="true"/>
+  <style name="def:thematic-break"          foreground="green" bold="true"/>
+  <style name="def:preformatted-section"    foreground="green"/>
+  <style name="def:list-marker"             foreground="teal" bold="true"/>
 
   <!-- Others -->
   <style name="def:preprocessor"            foreground="sky"/>
   <style name="def:error"                   foreground="red" bold="true"/>
+  <style name="def:warning"                 background="yellow"/>
   <style name="def:note"                    foreground="lavender" bold="true"/>
+  <style name="def:net-address"             foreground="blue" italic="true" underline="single"/>
   <style name="def:underlined"              italic="true" underline="single"/>
+  <style name="def:function"                foreground="blue"/>
 
-  <!-- Heading styles, uncomment to enable -->
-  <!--
-  <style name="def:heading0"                scale="5.0"/>
-  <style name="def:heading1"                scale="2.5"/>
-  <style name="def:heading2"                scale="2.0"/>
-  <style name="def:heading3"                scale="1.7"/>
-  <style name="def:heading4"                scale="1.5"/>
-  <style name="def:heading5"                scale="1.3"/>
-  <style name="def:heading6"                scale="1.2"/>
-  -->
+  <!-- Diff -->
+  <style name="diff:location"               foreground="peach"/>
+  <style name="diff:changed-line"           foreground="blue"/>
+  <style name="diff:added-line"             foreground="green"/>
+  <style name="diff:removed-line"           foreground="red"/>
+  <style name="diff:special-case"           foreground="peach"/>
 </style-scheme>

--- a/src/mocha.xml
+++ b/src/mocha.xml
@@ -58,31 +58,41 @@ SOFTWARE.
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>
-  <style name="selection"                   foreground="crust" background="text"/>
-  <style name="cursor"                      foreground="subtext0"/>
-  <style name="secondary-cursor"            foreground="subtext1"/>
-  <style name="current-line"                background="text"/>
-  <style name="line-numbers"                foreground="text" background="base"/>
+  <style name="selection"                   foreground="text" background="surface2"/>
+  <style name="selection-unfocused"         foreground="text" background="overlay2"/>
+  <style name="cursor"                      foreground="rosewater"/>
+  <style name="secondary-cursor"            foreground="rosewater"/>
+  <style name="current-line"                background="surface0"/>
+  <style name="line-numbers"                foreground="overlay1" background="base"/>
   <style name="background-pattern"          background="rosewater"/>
 
   <!-- Bracket Matching -->
-  <style name="bracket-match"               foreground="crust" background="base"/>
+  <style name="bracket-match"               foreground="mauve"/>
   <style name="bracket-mismatch"            foreground="red" background="base"/>
 
   <!-- Right Margin -->
-  <style name="right-margin"                foreground="crust" background="base"/>
+  <style name="right-margin"                foreground="text" background="crust"/>
 
   <!-- Search Matching -->
-  <style name="search-match"                foreground="crust" background="yellow"/>
+  <style name="search-match"                foreground="text" background="teal"/>
 
   <!-- Comments -->
-  <style name="def:comment"                 foreground="subtext0"/>
-  <style name="def:shebang"                 foreground="subtext0" bold="true"/>
+  <style name="def:comment"                 foreground="overlay2"/>
+  <style name="def:shebang"                 foreground="overlay0" bold="true"/>
   <style name="def:doc-comment-element"     italic="true"/>
 
-  <!-- Constants -->
-  <style name="def:constant"                foreground="green"/>
-  <style name="def:special-char"            foreground="green"/>
+  <!-- Constants and variables -->
+  <style name="def:constant"                foreground="peach"/>
+  <style name="def:string"                  foreground="green"/>
+  <style name="def:special-char"            foreground="pink"/>
+  <style name="def:special-constant"        foreground="peach" bold="true"/>
+  <style name="def:number"                  foreground="peach"/>
+  <style name="def:floating-point"          foreground="peach"/>
+  <style name="def:boolean"                 foreground="peach"/>
+  <style name="def:keyword"                 foreground="mauve" bold="true"/>
+  <style name="def:builtin"                 foreground="red" bold="true"/>
+  <style name="def:variable"                foreground="maroon"/>
+
 
   <!-- Identifiers -->
   <style name="def:identifier"              foreground="blue"/>
@@ -94,22 +104,35 @@ SOFTWARE.
   <style name="def:type"                    foreground="yellow"/>
 
   <!-- Operators -->
-  <style name="def:operator"                foreground="teal"/>
+  <style name="def:operator"                foreground="sky"/>
+
+  <!-- Markup -->
+  <style name="def:emphasis"                italic="true"/>
+  <style name="def:strong-emphasis"         foreground="yellow" bold="true"/>
+  <style name="def:inline-code"             foreground="green"/>
+  <style name="def:insertion"               underline="single"/>
+  <style name="def:deletion"                strikethrough="true"/>
+  <style name="def:link-text"               foreground="lavender"/>
+  <style name="def:link-symbol"             foreground="blue" bold="true"/>
+  <style name="def:link-destination"        foreground="blue" italic="true" underline="single"/>
+  <style name="def:heading"                 foreground="red" bold="true"/>
+  <style name="def:thematic-break"          foreground="green" bold="true"/>
+  <style name="def:preformatted-section"    foreground="green"/>
+  <style name="def:list-marker"             foreground="teal" bold="true"/>
 
   <!-- Others -->
   <style name="def:preprocessor"            foreground="sky"/>
   <style name="def:error"                   foreground="red" bold="true"/>
+  <style name="def:warning"                 background="yellow"/>
   <style name="def:note"                    foreground="lavender" bold="true"/>
+  <style name="def:net-address"             foreground="blue" italic="true" underline="single"/>
   <style name="def:underlined"              italic="true" underline="single"/>
+  <style name="def:function"                foreground="blue"/>
 
-  <!-- Heading styles, uncomment to enable -->
-  <!--
-  <style name="def:heading0"                scale="5.0"/>
-  <style name="def:heading1"                scale="2.5"/>
-  <style name="def:heading2"                scale="2.0"/>
-  <style name="def:heading3"                scale="1.7"/>
-  <style name="def:heading4"                scale="1.5"/>
-  <style name="def:heading5"                scale="1.3"/>
-  <style name="def:heading6"                scale="1.2"/>
-  -->
+  <!-- Diff -->
+  <style name="diff:location"               foreground="peach"/>
+  <style name="diff:changed-line"           foreground="blue"/>
+  <style name="diff:added-line"             foreground="green"/>
+  <style name="diff:removed-line"           foreground="red"/>
+  <style name="diff:special-case"           foreground="peach"/>
 </style-scheme>

--- a/xed.tera
+++ b/xed.tera
@@ -50,7 +50,7 @@ whiskers:
   <!-- Constants and variables -->
   <style name="def:constant"                foreground="peach"/>
   <style name="def:string"                  foreground="green"/>
-  <style name="def:special-char"            foreground="green" bold="true"/>
+  <style name="def:special-char"            foreground="pink"/>
   <style name="def:special-constant"        foreground="peach" bold="true"/>
   <style name="def:number"                  foreground="peach"/>
   <style name="def:floating-point"          foreground="peach"/>

--- a/xed.tera
+++ b/xed.tera
@@ -67,7 +67,7 @@ whiskers:
   <style name="def:statement"               foreground="peach" bold="true"/>
 
   <!-- Types -->
-  <style name="def:type"                    foreground="yellow" bold="true"/>
+  <style name="def:type"                    foreground="yellow"/>
 
   <!-- Operators -->
   <style name="def:operator"                foreground="sky"/>

--- a/xed.tera
+++ b/xed.tera
@@ -78,7 +78,7 @@ whiskers:
   <style name="def:inline-code"             foreground="green"/>
   <style name="def:insertion"               underline="single"/>
   <style name="def:deletion"                strikethrough="true"/>
-  <style name="def:link-text"               foreground="rosewater"/>
+  <style name="def:link-text"               foreground="lavender"/>
   <style name="def:link-symbol"             foreground="blue" bold="true"/>
   <style name="def:link-destination"        foreground="blue" italic="true" underline="single"/>
   <style name="def:heading"                 foreground="red" bold="true"/>

--- a/xed.tera
+++ b/xed.tera
@@ -81,7 +81,7 @@ whiskers:
   <style name="def:link-text"               foreground="rosewater"/>
   <style name="def:link-symbol"             foreground="blue" bold="true"/>
   <style name="def:link-destination"        foreground="blue" italic="true" underline="single"/>
-  <style name="def:heading"                 foreground="teal" bold="true"/>
+  <style name="def:heading"                 foreground="red" bold="true"/>
   <style name="def:thematic-break"          foreground="green" bold="true"/>
   <style name="def:preformatted-section"    foreground="green"/>
   <style name="def:list-marker"             foreground="teal" bold="true"/>
@@ -101,15 +101,4 @@ whiskers:
   <style name="diff:added-line"             foreground="green"/>
   <style name="diff:removed-line"           foreground="red"/>
   <style name="diff:special-case"           foreground="peach"/>
-
-  <!-- Heading styles, uncomment to enable -->
-  <!--
-  <style name="def:heading0"                scale="5.0"/>
-  <style name="def:heading1"                scale="2.5"/>
-  <style name="def:heading2"                scale="2.0"/>
-  <style name="def:heading3"                scale="1.7"/>
-  <style name="def:heading4"                scale="1.5"/>
-  <style name="def:heading5"                scale="1.3"/>
-  <style name="def:heading6"                scale="1.2"/>
-  -->
 </style-scheme>

--- a/xed.tera
+++ b/xed.tera
@@ -13,7 +13,7 @@ whiskers:
 
 {{ read_file(path="LICENSE") }}
 -->
-<style-scheme id="catppuccin-{{ flavor.identifier }}" _name="Catppuccin {{ flavor.identifier | capitalize }}" version="1.0">
+<style-scheme id="catppuccin-{{ flavor.identifier }}" _name="Catppuccin {{ flavor.name }}" version="1.0">
   <author>Catppuccin</author>
   <_description>Soothing pastel theme for Xed</_description>
 
@@ -24,49 +24,83 @@ whiskers:
 
   <!-- Global Settings -->
   <style name="text"                        foreground="text" background="base"/>
-  <style name="selection"                   foreground="crust" background="text"/>
-  <style name="cursor"                      foreground="subtext0"/>
-  <style name="secondary-cursor"            foreground="subtext1"/>
-  <style name="current-line"                background="text"/>
-  <style name="line-numbers"                foreground="text" background="base"/>
+  <style name="selection"                   foreground="text" background="surface2"/>
+  <style name="selection-unfocused"         foreground="text" background="overlay2"/>
+  <style name="cursor"                      foreground="rosewater"/>
+  <style name="secondary-cursor"            foreground="rosewater"/>
+  <style name="current-line"                background="surface0"/>
+  <style name="line-numbers"                foreground="overlay1" background="base"/>
   <style name="background-pattern"          background="rosewater"/>
 
   <!-- Bracket Matching -->
-  <style name="bracket-match"               foreground="crust" background="base"/>
+  <style name="bracket-match"               foreground="mauve"/>
   <style name="bracket-mismatch"            foreground="red" background="base"/>
 
   <!-- Right Margin -->
-  <style name="right-margin"                foreground="crust" background="base"/>
+  <style name="right-margin"                foreground="text" background="crust"/>
 
   <!-- Search Matching -->
-  <style name="search-match"                foreground="crust" background="yellow"/>
+  <style name="search-match"                foreground="text" background="teal"/>
 
   <!-- Comments -->
-  <style name="def:comment"                 foreground="subtext0"/>
-  <style name="def:shebang"                 foreground="subtext0" bold="true"/>
+  <style name="def:comment"                 foreground="overlay0"/>
+  <style name="def:shebang"                 foreground="overlay0" bold="true"/>
   <style name="def:doc-comment-element"     italic="true"/>
 
-  <!-- Constants -->
-  <style name="def:constant"                foreground="green"/>
-  <style name="def:special-char"            foreground="green"/>
+  <!-- Constants and variables -->
+  <style name="def:constant"                foreground="peach"/>
+  <style name="def:string"                  foreground="green"/>
+  <style name="def:special-char"            foreground="green" bold="true"/>
+  <style name="def:special-constant"        foreground="peach" bold="true"/>
+  <style name="def:number"                  foreground="peach"/>
+  <style name="def:floating-point"          foreground="peach"/>
+  <style name="def:boolean"                 foreground="peach"/>
+  <style name="def:keyword"                 foreground="mauve" bold="true"/>
+  <style name="def:builtin"                 foreground="red" bold="true"/>
+  <style name="def:variable"                foreground="maroon"/>
+
 
   <!-- Identifiers -->
   <style name="def:identifier"              foreground="blue"/>
 
   <!-- Statements -->
-  <style name="def:statement"               foreground="peach"/>
+  <style name="def:statement"               foreground="peach" bold="true"/>
 
   <!-- Types -->
-  <style name="def:type"                    foreground="yellow"/>
+  <style name="def:type"                    foreground="yellow" bold="true"/>
 
   <!-- Operators -->
-  <style name="def:operator"                foreground="teal"/>
+  <style name="def:operator"                foreground="sky"/>
+
+  <!-- Markup -->
+  <style name="def:emphasis"                italic="true"/>
+  <style name="def:strong-emphasis"         foreground="yellow" bold="true"/>
+  <style name="def:inline-code"             foreground="green"/>
+  <style name="def:insertion"               underline="single"/>
+  <style name="def:deletion"                strikethrough="true"/>
+  <style name="def:link-text"               foreground="rosewater"/>
+  <style name="def:link-symbol"             foreground="blue" bold="true"/>
+  <style name="def:link-destination"        foreground="blue" italic="true" underline="single"/>
+  <style name="def:heading"                 foreground="teal" bold="true"/>
+  <style name="def:thematic-break"          foreground="green" bold="true"/>
+  <style name="def:preformatted-section"    foreground="green"/>
+  <style name="def:list-marker"             foreground="teal" bold="true"/>
 
   <!-- Others -->
   <style name="def:preprocessor"            foreground="sky"/>
   <style name="def:error"                   foreground="red" bold="true"/>
+  <style name="def:warning"                 background="yellow"/>
   <style name="def:note"                    foreground="lavender" bold="true"/>
+  <style name="def:net-address"             foreground="blue" italic="true" underline="single"/>
   <style name="def:underlined"              italic="true" underline="single"/>
+  <style name="def:function"                foreground="blue"/>
+
+  <!-- Diff -->
+  <style name="diff:location"               foreground="peach"/>
+  <style name="diff:changed-line"           foreground="blue"/>
+  <style name="diff:added-line"             foreground="green"/>
+  <style name="diff:removed-line"           foreground="red"/>
+  <style name="diff:special-case"           foreground="peach"/>
 
   <!-- Heading styles, uncomment to enable -->
   <!--

--- a/xed.tera
+++ b/xed.tera
@@ -64,7 +64,7 @@ whiskers:
   <style name="def:identifier"              foreground="blue"/>
 
   <!-- Statements -->
-  <style name="def:statement"               foreground="peach" bold="true"/>
+  <style name="def:statement"               foreground="peach"/>
 
   <!-- Types -->
   <style name="def:type"                    foreground="yellow"/>

--- a/xed.tera
+++ b/xed.tera
@@ -43,7 +43,7 @@ whiskers:
   <style name="search-match"                foreground="text" background="teal"/>
 
   <!-- Comments -->
-  <style name="def:comment"                 foreground="overlay0"/>
+  <style name="def:comment"                 foreground="overlay2"/>
   <style name="def:shebang"                 foreground="overlay0" bold="true"/>
   <style name="def:doc-comment-element"     italic="true"/>
 


### PR DESCRIPTION
This update brings support to a wider array of properties and file types, and further enforces specifications from the [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md). References were taken from other themes, including the Gedit port of [Catppuccin](https://github.com/catppuccin/gedit) and [Nord](https://github.com/nordtheme/gedit).

To be honest, I'm not quire sure what _some_ of these properties are supposed to do, but this should be enough to make the theme considerably more extensive and fix [issue #1](https://github.com/catppuccin/xed/issues/1), which has been sitting there for over two years.

It also reverts commit 862ac6473bf78433e967c335c9d6ed46822947fa, as the accented `é` seems to work perfectly fine within Xed.